### PR TITLE
docs: normalize profile README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ graph TD
 
 ```
 
-###📡 Network & Archives
+### 📡 Network & Archives
+
 | Platform | Handle/Link | Context |
 | --- | --- | --- |
 | **GitHub** | [bitRAKE](https://github.com/bitRAKE) | Current Repositories |
@@ -42,7 +43,7 @@ graph TD
 | **Twitter** | [@bitRAKE_hacked](https://twitter.com/bitRAKE_hacked) | Updates & Thoughts |
 | **YouTube** | [Channel Link](https://www.youtube.com/bitRAKE) | Visual Projects |
 
-###🧰 Preferred Toolchain
+### 🧰 Preferred Toolchain
 
 **Development & Visualization**
 
@@ -67,7 +68,8 @@ graph TD
 * [The Buckblog](https://weblog.jamisbuck.org/) - assorted ramblings by Jamis Buck
 * ... so many more to add ...
 
-###📊 Activity Timeline (1983 - Present)
+### 📊 Activity Timeline (1983 - Present)
+
 ```mermaid
 gantt
     title Professional Evolution


### PR DESCRIPTION
## Summary
- Normalize the profile README's emoji section headings to CommonMark/GitHub-friendly ATX heading syntax by adding the required space after `###`.
- Add blank lines between headings and the following table/fenced Mermaid block so the profile renders consistently across Markdown parsers.

## Verification
- `python3` README check: passed; no ATX heading spacing violations and all local Markdown links resolve.
- `git diff --check`: passed.

## Notes / Limitations
- Documentation-only profile README change; no build or runtime test is applicable.
